### PR TITLE
Set default value to unused Scenario fields

### DIFF
--- a/app/projects/forms.py
+++ b/app/projects/forms.py
@@ -391,7 +391,7 @@ class ScenarioCreateForm(OpenPlanModelForm):
 
     class Meta:
         model = Scenario
-        exclude = ["id"]
+        exclude = ["id", "capex_var", "opex_fix", "opex_var"]
         widgets = scenario_widgets
         labels = scenario_labels
 
@@ -411,7 +411,7 @@ class ScenarioUpdateForm(OpenPlanModelForm):
 
     class Meta:
         model = Scenario
-        exclude = ["id"]
+        exclude = ["id", "capex_var", "opex_fix", "opex_var"]
         widgets = scenario_widgets
         labels = scenario_labels
 

--- a/app/projects/models/base_models.py
+++ b/app/projects/models/base_models.py
@@ -84,7 +84,21 @@ class Scenario(models.Model):
 
     start_date = models.DateTimeField()
     time_step = models.IntegerField(validators=[MinValueValidator(0)])
-    capex_fix = models.FloatField(validators=[MinValueValidator(0.0)])
+    capex_fix = models.FloatField(
+        validators=[MinValueValidator(0.0)], default=0, blank=True
+    )
+    # The next 3 fields make no sense for a scenario, they are asset fields.
+    # Removing them caused trouble with existing database though, so default values are used instead
+    # related to https://github.com/open-plan-tool/gui/issues/32
+    capex_var = models.FloatField(
+        validators=[MinValueValidator(0.0)], default=0, blank=True
+    )
+    opex_fix = models.FloatField(
+        validators=[MinValueValidator(0.0)], default=0, blank=True
+    )
+    opex_var = models.FloatField(
+        validators=[MinValueValidator(0.0)], default=0, blank=True
+    )
     evaluated_period = models.IntegerField(validators=[MinValueValidator(0)])
     project = models.ForeignKey(Project, on_delete=models.CASCADE, null=True)
 


### PR DESCRIPTION
This is because existing instances in database would raise error if the
fields are simply removed

Related to #32 