### PR TITLE
Allow production asset max capacity

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -462,12 +462,12 @@ class ReportItem(models.Model):
                         )
                         if y_var in kpi_scalar_matrix:
                             optimized_capacity_dict["capacity"].append(
-                                kpi_scalar_matrix[y_var]["optimizedAddCap"]
+                                kpi_scalar_matrix[y_var]["optimized_add_cap"]
                             )
                         else:
-                            if "optimizedAddCap" in asset:
+                            if "optimized_add_cap" in asset:
                                 optimized_capacity_dict["capacity"].append(
-                                    asset["optimizedAddCap"]["value"]
+                                    asset["optimized_add_cap"]["value"]
                                 )
                             else:
                                 optimized_capacity_dict["capacity"].append(0)

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -986,7 +986,7 @@ def scenario_visualize_stacked_capacities(request, scen_id):
         )
 
 
-# TODO: push optimizedAddCap for DSO to KPI as "Spitzenlast"/ "Peak Demand"
+# TODO: push optimized_add_cap for DSO to KPI as "Spitzenlast"/ "Peak Demand"
 # TODO: Make a note appear if all components have optimized_capacity = False because no figure will be shown
 # TODO: Change "if results_dict = json.loads(Scenario.objects.first().simulation.results)"
 def scenario_visualize_stacked_optimized_capacities(request, scen_id):
@@ -1016,7 +1016,7 @@ def scenario_visualize_stacked_optimized_capacities(request, scen_id):
                 "values": [
                     {
                         "x": ["Optimierte Kapazität"],
-                        "y": [kpi_scalar_matrix[asset]["optimizedAddCap"]],
+                        "y": [kpi_scalar_matrix[asset]["optimized_add_cap"]],
                         "name": asset.replace("_", " ").upper()
                         + " in "
                         + kpi_scalar_matrix[asset]["unit"]

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -47,6 +47,7 @@ import xlsxwriter
 import json
 import datetime
 import logging
+import traceback
 import ast
 
 logger = logging.getLogger(__name__)
@@ -91,7 +92,7 @@ def scenario_available_results(request, scen_id):
         return JsonResponse(response_json, status=200, content_type="application/json")
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"error": "Could not retrieve asset names and categories."},
@@ -170,7 +171,7 @@ def scenario_request_results(request, scen_id):
         )
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"Error": "Could not retrieve timeseries data."},
@@ -740,7 +741,7 @@ def scenario_economic_results(request, scen_id=None):
         )
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"error": f"Could not retrieve kpi cost data."},
@@ -798,7 +799,7 @@ def scenario_visualize_timeseries(request, scen_id):
         )
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"error": f"Could not retrieve kpi cost data."},
@@ -871,7 +872,7 @@ def scenario_visualize_stacked_timeseries(request, scen_id):
         )
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"error": f"Could not retrieve kpi cost data."},
@@ -925,7 +926,7 @@ def scenario_visualize_stacked_total_flow(request, scen_id):
         )
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"error": f"Could not retrieve kpi cost data."},
@@ -976,7 +977,7 @@ def scenario_visualize_stacked_capacities(request, scen_id):
         )
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"error": f"Could not retrieve kpi cost data."},
@@ -1038,7 +1039,7 @@ def scenario_visualize_stacked_optimized_capacities(request, scen_id):
         )
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {e}"
+            f"Dashboard ERROR: MVS Req Id: {scenario.simulation.mvs_token}. Thrown Exception: {traceback.format_exc()}"
         )
         return JsonResponse(
             {"error": f"Could not retrieve kpi cost data."},
@@ -1080,7 +1081,7 @@ def download_scalar_results(request, scen_id):
         output.seek(0)
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: Could not generate KPI Scalars download file with Scenario Id: {scen_id}. Thrown Exception: {e}"
+            f"Dashboard ERROR: Could not generate KPI Scalars download file with Scenario Id: {scen_id}. Thrown Exception: {traceback.format_exc()}"
         )
         raise Http404()
 
@@ -1125,7 +1126,7 @@ def download_cost_results(request, scen_id):
         output.seek(0)
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: Could not generate KPI Costs download file with Scenario Id: {scen_id}. Thrown Exception: {e}"
+            f"Dashboard ERROR: Could not generate KPI Costs download file with Scenario Id: {scen_id}. Thrown Exception: {traceback.format_exc()}"
         )
         raise Http404()
 
@@ -1235,7 +1236,7 @@ def download_timeseries_results(request, scen_id):
         return response
     except Exception as e:
         logger.error(
-            f"Dashboard ERROR: Could not generate Timeseries Results file for the Scenario with Id: {scen_id}. Thrown Exception: {e}"
+            f"Dashboard ERROR: Could not generate Timeseries Results file for the Scenario with Id: {scen_id}. Thrown Exception: {traceback.format_exc()}"
         )
         raise Http404()
 

--- a/app/projects/models/base_models.py
+++ b/app/projects/models/base_models.py
@@ -292,6 +292,12 @@ class AssetType(models.Model):
     def visible_fields(self):
         return self.asset_fields.replace("[", "").replace("]", "").split(",")
 
+    def add_field(self, field_name):
+        temp = self.visible_fields
+        if field_name not in temp:
+            temp.append(field_name)
+            self.asset_fields = "[" + ",".join(temp) + "]"
+
 
 class TopologyNode(models.Model):
     name = models.CharField(max_length=60, null=False, blank=False)

--- a/app/projects/views.py
+++ b/app/projects/views.py
@@ -697,15 +697,15 @@ def scenario_create_constraints(request, proj_id, scen_id, step_id=3, max_step=4
         "net_zero_energy": _("Net zero energy system"),
     }
     constraints_forms = {
-        "minimal_degree_of_autonomy": MinRenewableConstraintForm,
-        "minimal_renewable_factor": MinDOAConstraintForm,
+        "minimal_degree_of_autonomy": MinDOAConstraintForm,
+        "minimal_renewable_factor": MinRenewableConstraintForm,
         "maximum_emissions": MaxEmissionConstraintForm,
         "net_zero_energy": NZEConstraintForm,
     }
 
     constraints_models = {
-        "minimal_degree_of_autonomy": MinRenewableConstraint,
-        "minimal_renewable_factor": MinDOAConstraint,
+        "minimal_degree_of_autonomy": MinDOAConstraint,
+        "minimal_renewable_factor": MinRenewableConstraint,
         "maximum_emissions": MaxEmissionConstraint,
         "net_zero_energy": NZEConstraint,
     }

--- a/app/projects/views.py
+++ b/app/projects/views.py
@@ -1219,11 +1219,11 @@ def view_mvs_data_input(request, scen_id=0):
             content_type="application/json",
         )
     # Load scenario
-    scenario = Scenario.objects.get(pk=scen_id)
+    scenario = Scenario.objects.get(id=scen_id)
 
     if scenario.project.user != request.user:
         logger.warning(
-            f"Unauthorized user tried to delete project scenario with db id = {scen_id}."
+            f"Unauthorized user tried to access scenario with db id = {scen_id}."
         )
         raise PermissionDenied
 

--- a/app/templates/scenario/simulation/pending.html
+++ b/app/templates/scenario/simulation/pending.html
@@ -32,12 +32,6 @@
 
       <div>
         <a class="btn btn--medium btn--hollow" href="{% url 'simulation_cancel' scen_id %}" onclick="return confirm('Are you sure?')">{% translate "Cancel simulation" %}</a>
-        <form method="post" action="{% url 'request_mvs_simulation' scen_id %}">
-            {% csrf_token %}
-
-            <button class="btn btn--medium btn--hollow" type="submit" > {% translate "Rerun simulation" %}</button>
-            <input type="checkbox" name="output_lp_file"> Include LP file (advanced users) </input>
-        </form>
       </div>
     </footer>
 {% endblock footer %}


### PR DESCRIPTION
Linked to https://github.com/rl-institut/multi-vector-simulator/pull/939

Closes #117 

Added manually "maximum_capacity" to the `asset_fields` of the model instances of AssetType which are for production assets

This code was ran on the database

```python
from projects.models import *
from dashboard.models import *

for to_replace in ("optimizedAddCap", "optimize_add_cap"):
    for sim in Simulation.objects.filter(results__contains=to_replace):
        sim.results = sim.results.replace(to_replace, "optimized_add_cap")
        sim.save()
        print("Simulation ", sim.id, "had ", to_replace)

    for sim in AssetsResults.objects.filter(assets_list__contains=to_replace):
        sim.assets_list = sim.assets_list.replace(
            to_replace, "optimized_add_cap"
        )
        sim.save()
        print("AssetsResults ", sim.id, "had ", to_replace)
```

