### PR TITLE
Add passwort reset

### DIFF
--- a/.github/workflows/black_linter.yml
+++ b/.github/workflows/black_linter.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install black==19.3b pytest
         pip install click==8.0.2
-        pip install -r app/requirements/mysql.txt
+        pip install -r app/requirements/postgres.txt
     - name: Analysing the code with pylint
       run: |
         black --check .

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ SQL_USER=<your user name>
 SQL_PASSWORD=<your password>
 SQL_HOST=localhost
 SQL_PORT=5432
+DEBUG=(True|False)
 ```
 8. Add an environment variable `MVS_HOST_API` and set the url of the simulation server you wish to use for your models
 9. Execute the `local_setup.sh` file (`. local_setup.sh` on linux/mac `bash local_setup.sh` on windows) you might have to make it executable first. Answer yes to the question

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -166,7 +166,7 @@ LOGOUT_REDIRECT_URL = "home"
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 MAILER_EMAIL_BACKEND = EMAIL_BACKEND
 
 DEFAULT_FROM_EMAIL = "noreply@elandh2020.eu"

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -11,11 +11,11 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 import ast
 import os
+
 from django.contrib.messages import constants as messages
 
-
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = ast.literal_eval(os.getenv("DEBUG", "True"))
+DEBUG = ast.literal_eval(os.getenv("DEBUG", "False"))
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -40,7 +40,6 @@ SECRET_KEY = os.getenv(
     "EPA_SECRET_KEY", "v@p9^=@lc3#1u_xtx*^xhrv0l3li1(+8ik^k@g-_bzmexb0$7n"
 )
 
-
 ALLOWED_HOSTS = ["*"]
 
 # Application definition
@@ -63,7 +62,6 @@ INSTALLED_APPS = [
 
 if DEBUG is True:
     INSTALLED_APPS.append("sass_processor")
-
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -125,7 +123,6 @@ DATABASES = {
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
-
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
 
@@ -155,7 +152,6 @@ USE_L10N = True
 
 USE_TZ = False
 
-
 # Other configs
 
 AUTH_USER_MODEL = "users.CustomUser"
@@ -166,7 +162,10 @@ LOGOUT_REDIRECT_URL = "home"
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+if DEBUG is True:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 MAILER_EMAIL_BACKEND = EMAIL_BACKEND
 
 DEFAULT_FROM_EMAIL = "noreply@elandh2020.eu"

--- a/app/templates/registration/login.html
+++ b/app/templates/registration/login.html
@@ -9,24 +9,31 @@
 
 {% block index %}
 
-<main class="signup">
-    <div class="signup-frame">
-        <div class="signup-frame__img">
-            <img src="{% static 'assets/illustrations/open_plan_hero_hexagon.svg' %}" alt="open_plan cells">
+    <main class="signup">
+        <div class="signup-frame">
+            <div class="signup-frame__img">
+                <img src="{% static 'assets/illustrations/open_plan_hero_hexagon.svg' %}"
+                     alt="open_plan cells">
+            </div>
+            <div class="signup-frame__heading">
+                {% translate "Welcome to the open_plan tool" %}
+            </div>
+            <div class="signup-frame__subheading">
+                Do you not have an account yet? <a
+                    href="{% url 'signup' %}">{% translate "Sign up" %}</a>
+            </div>
+            <div class="signup-frame__subheading">
+                {% trans "Forgot your password?" %} <a
+                    href="{% url 'password_reset' %}">{% trans "Reset Password" %}</a>
+            </div>
+            <form method="post" class="signup-frame__form">
+                {% csrf_token %}
+                {{ form|crispy }}
+                <button class="btn btn--large" type="submit"
+                        id="loginbutton">{% translate "Login" %}</button>
+            </form>
         </div>
-        <div class="signup-frame__heading">
-            {% translate "Welcome to the open_plan tool" %}
-        </div>
-        <div class="signup-frame__subheading">
-            Do you not have an account yet? <a href="{% url 'signup' %}">{% translate "Sign up" %}</a>
-        </div>
-        <form method="post" class="signup-frame__form">
-            {% csrf_token %}
-            {{ form|crispy }}
-            <button class="btn btn--large" type="submit" id="loginbutton">{% translate "Login" %}</button>
-        </form>
-    </div>
-</main>
+    </main>
 
 
 {% endblock index %}

--- a/app/templates/registration/login.html
+++ b/app/templates/registration/login.html
@@ -23,14 +23,6 @@
         <form method="post" class="signup-frame__form">
             {% csrf_token %}
             {{ form|crispy }}
-            <!--<div class="mb-3">
-                <label for="id_username" class="form-label">{% translate "Email address" %}</label>
-                <input type="text" class="form-control form-control-lg" id="id_username" placeholder="name@example.com" required name="username">
-            </div>
-            <div class="mb-3">
-                <label for="id_password" class="form-label">{% translate "Password" %}</label>
-                <input type="password" class="form-control form-control-lg" id="id_password" placeholder="Password with at least 8 characters" required name="password">
-            </div>-->
             <button class="btn btn--large" type="submit" id="loginbutton">{% translate "Login" %}</button>
         </form>
     </div>

--- a/app/templates/registration/password_reset_complete.html
+++ b/app/templates/registration/password_reset_complete.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+
+    <div class="container p-5">
+	    <h2 class="font-weight-bold mt-3">{% trans "Password reset complete" %}</h2>
+		<hr>
+        <p>{% trans "Your password has been set. You may go ahead and log in now." %}</p>
+        <a href="{% url 'login' %}" class="btn btn-primary">{% trans "Log in" %}</a>
+    </div>
+
+{% endblock %}

--- a/app/templates/registration/password_reset_confirm.html
+++ b/app/templates/registration/password_reset_confirm.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+
+  {% load crispy_forms_tags %}
+
+    <div class="container p-5">
+	    <h2 class="font-weight-bold mt-3">{% trans "Password Reset Confirm" %}</h2>
+		<hr>
+        <p>{% trans "Please enter your new password." %}</p>
+        <form method="POST">
+            {% csrf_token %}
+            {{ form|crispy }}
+            <button class="btn btn-primary" type="submit">{% trans "Reset password" %}</button>
+        </form>
+    </div>
+
+{% endblock %}

--- a/app/templates/registration/password_reset_done.html
+++ b/app/templates/registration/password_reset_done.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+
+    <div class="container p-5">
+        <h2 class="font-weight-bold mt-3">{% trans "Password reset sent" %}</h2>
+        <hr>
+        <p>{% trans "We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly." %}</p>
+        <p>{% trans "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder." %}
+        </p>
+    </div>
+
+{% endblock %}

--- a/app/templates/registration/password_reset_form.html
+++ b/app/templates/registration/password_reset_form.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+
+	{% load crispy_forms_tags %}
+
+	<div class="container p-5">
+  	 	<h2 class="font-weight-bold mt-3">{% trans "Reset Password" %}</h2>
+		<hr>
+		<p>{% trans "Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one." %}</p>
+        <form method="POST">
+            {% csrf_token %}
+            {{ form|crispy }}
+            <button class="btn btn-primary" type="submit">{%  trans "Send email" %}</button>
+        </form>
+  	</div>
+
+{% endblock %}

--- a/app/templates/registration/signup.html
+++ b/app/templates/registration/signup.html
@@ -27,14 +27,6 @@
         <form method="post" class="signup-frame__form">
             {% csrf_token %}
             {{ form|crispy }}
-            <!--<div class="mb-3">
-                <label for="id_email" class="form-label">{% translate "Email address" %}</label>
-                <input type="text" class="form-control form-control-lg" id="id_email" placeholder="name@example.com" required>
-            </div>
-            <div class="mb-3">
-                <label for="id_password1" class="form-label">{% translate "Password" %}</label>
-                <input type="password" class="form-control form-control-lg" id="id_password1" placeholder="Password with at least 8 characters" required>
-            </div>-->
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">
                 <label class="form-check-label" for="flexCheckDefault">

--- a/app/templates/registration/user_info.html
+++ b/app/templates/registration/user_info.html
@@ -1,55 +1,52 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
 {% load crispy_forms_tags %}
 
 {% block content %}
 
-<main>
-    <section class="header">
-        <div>
-            <div class="header__left"></div>
-            <h1 class="header__title">Account</h1>
-            <div class="header__back"></div>
-        </div>
-    </section>
-    <section class="standard-layout">
-        <div>
-            <div class="account">
-                <div>
-                    <form method="post">
-                        {% csrf_token %}
-                        {{ form|crispy }}
-                        <br>
-                        <div class="row">
-                            <div class="col-sm-4"></div>
-                            <div class="col-sm-4">
-                                <button class="btn btn-primary btn-lg" type="submit">Save Changes
-                                </button>
+    <main>
+        <section class="header">
+            <div>
+                <div class="header__left"></div>
+                <h1 class="header__title">Account</h1>
+                <div class="header__back"></div>
+            </div>
+        </section>
+        <section class="standard-layout">
+            <div>
+                <div class="account">
+                    <div>
+                        <form method="post">
+                            {% csrf_token %}
+                            {{ form|crispy }}
+                            <br>
+                            <div class="row">
+                                <div class="col-sm-4"></div>
+                                <div class="col-sm-4">
+                                    <button class="btn btn-primary btn-lg"
+                                            type="submit">Save Changes
+                                    </button>
+                                </div>
+                                <div class="col-sm-4"></div>
                             </div>
-                            <div class="col-sm-4"></div>
-                        </div>
-                        <br>
-                    </form>
-                    <!--<form>
-                        <div class="mb-3">
-                            <label for="nameInput" class="form-label">Name</label>
-                            <input type="email" class="form-control" id="nameInput" value="Christian Müller">
-                        </div>
-                        <div class="mb-3">
-                            <label for="emailInput" class="form-label">Email address</label>
-                            <input type="email" class="form-control" id="emailInput" value="christian.mueller@gmail.de">
-                        </div>
-                        <div class="mb-3">
-                            <label for="pwInput" class="form-label">Password</label>
-                            <input type="password" class="form-control" id="pwInput" value="*************">
-                        </div>
-                        <div class="account__save">
-                            <button type="submit" class="btn">Save changes</button>
-                        </div>
-                    </form>-->
+                            <br>
+                        </form>
+                    </div>
                 </div>
             </div>
-        </div>
-    </section>
-</main>
+        </section>
+        <section class="standard-layout">
+            <div>
+                <div class="account">
+                    <div>
+                        <a href="{% url 'password_reset' %}">
+                            <button class="btn btn-primary btn-lg"
+                                    type="submit">{% trans "Reset Password" %}</button>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
 {% endblock %}

--- a/app/users/forms.py
+++ b/app/users/forms.py
@@ -1,7 +1,5 @@
 from django import forms
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Field
 
 from .models import CustomUser
 

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.models import AbstractUser
-from django.db import models
 
 
 class CustomUser(AbstractUser):

--- a/app/users/tokens.py
+++ b/app/users/tokens.py
@@ -1,9 +1,0 @@
-from django.contrib.auth.tokens import PasswordResetTokenGenerator
-
-
-class AccountActivationTokenGenerator(PasswordResetTokenGenerator):
-    def _make_hash_value(self, user, timestamp):
-        return user.pk + timestamp + user.is_active
-
-
-account_activation_token = AccountActivationTokenGenerator()

--- a/app/users/urls.py
+++ b/app/users/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import *
+from .views import signup, change_password, user_info, activate, password_reset_request
 
 urlpatterns = [
     path("signup/", signup, name="signup"),
     path("change_password/", change_password, name="change_password"),
     path("user_info/", user_info, name="user_info"),
     path("activate/<uidb64>/<token>/", activate, name="activate"),
+    path("password_reset", password_reset_request, name="password_reset")
 ]

--- a/app/users/urls.py
+++ b/app/users/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     path("change_password/", change_password, name="change_password"),
     path("user_info/", user_info, name="user_info"),
     path("activate/<uidb64>/<token>/", activate, name="activate"),
-    path("password_reset", password_reset_request, name="password_reset")
+    path("password_reset", password_reset_request, name="password_reset"),
 ]

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -16,7 +16,6 @@ from django.urls.base import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views.decorators.http import require_http_methods
-
 from .forms import CustomUserCreationForm, CustomUserChangeForm
 from .models import CustomUser
 
@@ -28,11 +27,9 @@ UserModel = get_user_model()
 def signup(request):
     if request.method == "POST":
         form = CustomUserCreationForm(request.POST)
-        # print(form.errors.as_data())
         if form.is_valid():
             user = form.save(commit=False)
-            # user.is_active = False
-            user.is_active = True
+            user.is_active = False
             user.save()
             current_site = get_current_site(request)
             mail_subject = "Activate your account."
@@ -47,8 +44,8 @@ def signup(request):
             )
             to_email = form.cleaned_data.get("email")
             email = EmailMessage(mail_subject, message, to=[to_email])
-            # email.send()
-            # return HttpResponse('Please confirm your email address to complete the registration')
+            email.send()
+            return HttpResponse('Please confirm your email address to complete the registration')
             return HttpResponseRedirect(reverse("login"))
     else:
         form = CustomUserCreationForm()

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -108,7 +108,7 @@ def password_reset_request(request):
     if request.method == "POST":
         password_reset_form = PasswordResetForm(request.POST)
         if password_reset_form.is_valid():
-            data = password_reset_form.cleaned_data['email']
+            data = password_reset_form.cleaned_data["email"]
             associated_users = CustomUser.objects.filter(Q(email=data))
             if associated_users.exists():
                 for user in associated_users:
@@ -116,20 +116,28 @@ def password_reset_request(request):
                     email_template_name = "registration/password_reset_email.txt"
                     c = {
                         "email": user.email,
-                        'domain': EMAIL_HOST,
-                        'site_name': 'open_plan',
+                        "domain": EMAIL_HOST,
+                        "site_name": "open_plan",
                         "uid": urlsafe_base64_encode(force_bytes(user.pk)),
                         "user": user,
-                        'token': default_token_generator.make_token(user),
-                        'protocol': 'http',
+                        "token": default_token_generator.make_token(user),
+                        "protocol": "http",
                     }
                     email = render_to_string(email_template_name, c)
                     try:
-                        send_mail(subject, email, DEFAULT_FROM_EMAIL, [user.email],
-                                  fail_silently=False)
+                        send_mail(
+                            subject,
+                            email,
+                            DEFAULT_FROM_EMAIL,
+                            [user.email],
+                            fail_silently=False,
+                        )
                     except BadHeaderError:
-                        return HttpResponse('Invalid header found.')
+                        return HttpResponse("Invalid header found.")
                     return redirect("/password_reset/done/")
     password_reset_form = PasswordResetForm()
-    return render(request=request, template_name="registration/password_reset_form.html",
-                  context={"password_reset_form": password_reset_form})
+    return render(
+        request=request,
+        template_name="registration/password_reset_form.html",
+        context={"password_reset_form": password_reset_form},
+    )

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -9,10 +9,8 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMessage, send_mail, BadHeaderError
 from django.db.models import Q
 from django.http import HttpResponse
-from django.http.response import HttpResponseRedirect
 from django.shortcuts import render, redirect
 from django.template.loader import render_to_string
-from django.urls.base import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views.decorators.http import require_http_methods
@@ -45,8 +43,8 @@ def signup(request):
             to_email = form.cleaned_data.get("email")
             email = EmailMessage(mail_subject, message, to=[to_email])
             email.send()
-            return HttpResponse('Please confirm your email address to complete the registration')
-            return HttpResponseRedirect(reverse("login"))
+            messages.info(request, "Please confirm your email address to complete the registration")
+            return redirect("home")
     else:
         form = CustomUserCreationForm()
     return render(request, "registration/signup.html", {"form": form})
@@ -61,11 +59,11 @@ def activate(request, uidb64, token):
     if user is not None and default_token_generator.check_token(user, token):
         user.is_active = True
         user.save()
-        return HttpResponse(
-            "Thank you for your email confirmation. Now you can login your account."
-        )
+        messages.success(request, "Thank you for your email confirmation. Now you can login your account.")
+        return redirect("login")
     else:
         return HttpResponse("Activation link is invalid!")
+        return redirect("home")
 
 
 @login_required


### PR DESCRIPTION
Hi @Bachibouzouk,

Please review this PR and merge it if you approve.

This PR is based on the code of the open PRs #183 and #186. Those should be merged first. Also, the failing tests should be addressed. @Bachibouzouk can you address those tests before merging? It looks like they result from your code changes in #183.

I'm a friend of merging (if possible daily), even if something still needs to be finished. If we work in a team, merging branches that sit on a shell for too long often becomes very difficult.

Please speak up; if this process of merging your and my stuff often is not an option, then we have to find a different modus operandi.

Please also note:

- the places where I placed the password reset links (`/users/login` and `/users/user_info`) could be visually improved. Maybe a job for @bmlancien. I can write an issue and invite @bmlancien to work on it. What do you think?
- I used the console as email backend because no email system was given (or did I miss something?). I recommend staying with this until we go production because it makes testing the functionality fast.
