### PR TITLE
Improve database config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ SQL_ENGINE=django.db.backends.postgresql
 SQL_DATABASE=<your db name>
 SQL_USER=<your user name>
 SQL_PASSWORD=<your password>
+SQL_HOST=localhost
 SQL_PORT=5432
-DATABASE=postgres
 ```
 8. Add an environment variable `MVS_HOST_API` and set the url of the simulation server you wish to use for your models
 9. Execute the `local_setup.sh` file (`. local_setup.sh` on linux/mac `bash local_setup.sh` on windows) you might have to make it executable first. Answer yes to the question

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -104,27 +104,22 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "epa.wsgi.application"
 
-DB_CHOICE = os.environ.get("DATABASE", "postgres")
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-# By default the database is postgres, if you want to use mysql make sure you pip install the mysql requirement file
+# SQLite is used if no other database system is set via environment variables.
 DATABASES = {
     "default": {
-        "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
-        "NAME": os.environ.get("SQL_DATABASE", os.path.join(BASE_DIR, "db.sqlite3")),
-        "USER": os.environ.get("SQL_USER", "user"),
-        "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
-        "HOST": os.environ.get("SQL_HOST", "localhost"),
-        "PORT": os.environ.get("SQL_PORT", "5432"),
+        "ENGINE": os.environ.get("SQL_ENGINE"),
+        "NAME": os.environ.get("SQL_DATABASE"),
+        "USER": os.environ.get("SQL_USER"),
+        "PASSWORD": os.environ.get("SQL_PASSWORD"),
+        "HOST": os.environ.get("SQL_HOST"),
+        "PORT": os.environ.get("SQL_PORT"),
     }
-    if DB_CHOICE == "postgres"
+    if os.environ.get("SQL_ENGINE")
     else {
         "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
         "NAME": os.environ.get("SQL_DATABASE", os.path.join(BASE_DIR, "db.sqlite3")),
-        "USER": os.environ.get("SQL_USER", "user"),
-        "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
-        "HOST": os.environ.get("SQL_HOST", "localhost"),
-        "PORT": os.environ.get("SQL_PORT", "3306"),
     }
 }
 


### PR DESCRIPTION
@Bachibouzouk, please review and merge on approval.

Closes #194.

This PR improves the database config, because:

- before the config flow was kind of confusing, if nothing was set, the flag was named "postgres", but the values where set to use SQlite.
- now, if nothing is set, the default database system (DBS) in use is SQLite, but "any" other DBS can be used by explicitly setting it via environment variables.
- if some environment values are not properly set, it will now fail loudly instead of setting implicitly some values that the admin might has now knowledge of (happened to me)
- unneeded `DATABASE` environment variable is removed. If `SQL_ENGINE` is set, code will try to set custom database and will loudly fail if the rest of the environment variables are not not properly set.