### PR TITLE
Use explicit email backend switch

### DIFF
--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -162,10 +162,12 @@ LOGOUT_REDIRECT_URL = "home"
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
-if DEBUG is True:
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-else:
+USE_SMTP_EMAIL_BACKEND = ast.literal_eval(
+    os.getenv("USE_CONSOLE_EMAIL_BACKEND", "False"))
+if USE_SMTP_EMAIL_BACKEND is True:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 MAILER_EMAIL_BACKEND = EMAIL_BACKEND
 
 DEFAULT_FROM_EMAIL = "noreply@elandh2020.eu"

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -163,7 +163,8 @@ LOGOUT_REDIRECT_URL = "home"
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 USE_SMTP_EMAIL_BACKEND = ast.literal_eval(
-    os.getenv("USE_CONSOLE_EMAIL_BACKEND", "False"))
+    os.getenv("USE_CONSOLE_EMAIL_BACKEND", "False")
+)
 if USE_SMTP_EMAIL_BACKEND is True:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 else:

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -163,7 +163,7 @@ LOGOUT_REDIRECT_URL = "home"
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 USE_SMTP_EMAIL_BACKEND = ast.literal_eval(
-    os.getenv("USE_SMTP_EMAIL_BACKEND", "False")
+    os.getenv("USE_SMTP_EMAIL_BACKEND", "True")
 )
 if USE_SMTP_EMAIL_BACKEND is True:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -163,7 +163,7 @@ LOGOUT_REDIRECT_URL = "home"
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 USE_SMTP_EMAIL_BACKEND = ast.literal_eval(
-    os.getenv("USE_CONSOLE_EMAIL_BACKEND", "False")
+    os.getenv("USE_SMTP_EMAIL_BACKEND", "False")
 )
 if USE_SMTP_EMAIL_BACKEND is True:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
In preparation for #211 I need an explicit email backend switch because I want to be able to use email sending in debug mode. Sending the emails to the console might also be helpful in production for quick live debugging.

@Bachibouzouk, please review the changes made in this PR and merge on approval.
