### PR TITLE
Change/use exchange server for all mailing purposes

### DIFF
--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -144,7 +144,7 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 
 LANGUAGES = [("de", "German"), ("en", "English")]
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/Copenhagen"
 
 USE_I18N = True
 
@@ -162,19 +162,19 @@ LOGOUT_REDIRECT_URL = "home"
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
-USE_SMTP_EMAIL_BACKEND = ast.literal_eval(
-    os.getenv("USE_SMTP_EMAIL_BACKEND", "True")
+# Please note, we don't use Django's internal email system,
+# we implement our own, using exchangelib
+USE_EXCHANGE_EMAIL_BACKEND = ast.literal_eval(
+    os.getenv("USE_EXCHANGE_EMAIL_BACKEND", "True")
 )
-if USE_SMTP_EMAIL_BACKEND is True:
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-else:
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-MAILER_EMAIL_BACKEND = EMAIL_BACKEND
-
-DEFAULT_FROM_EMAIL = "noreply@elandh2020.eu"
-EMAIL_HOST = os.getenv("EMAIL_HOST_IP", "127.0.0.1")
-EMAIL_PORT = 25
-EMAIL_USE_TLS = False
+# Email account which will sends emails
+EXCHANGE_ACCOUNT = os.getenv("EXCHANGE_ACCOUNT", "dummy@dummy.com")
+EXCHANGE_PW = os.getenv("EXCHANGE_PW", "dummypw")
+EXCHANGE_EMAIL = os.getenv("EXCHANGE_EMAIL", "dummy@dummy.com")
+EXCHANGE_SERVER = os.getenv("EXCHANGE_SERVER", "dummy.com")
+# Email addresses to which feedback emails will be sent
+RECIPIENTS = os.getenv("RECIPIENTS", "dummy@dummy.com,dummy2@dummy.com").split(",")
+EMAIL_SUBJECT_PREFIX = os.getenv("EMAIL_SUBJECT_PREFIX", "[open_plan] ")
 
 MESSAGE_TAGS = {
     messages.DEBUG: "alert-info",

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -167,7 +167,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 USE_EXCHANGE_EMAIL_BACKEND = ast.literal_eval(
     os.getenv("USE_EXCHANGE_EMAIL_BACKEND", "True")
 )
-# Email account which will sends emails
+# The Exchange account which sends emails
 EXCHANGE_ACCOUNT = os.getenv("EXCHANGE_ACCOUNT", "dummy@dummy.com")
 EXCHANGE_PW = os.getenv("EXCHANGE_PW", "dummypw")
 EXCHANGE_EMAIL = os.getenv("EXCHANGE_EMAIL", "dummy@dummy.com")

--- a/app/epa/urls.py
+++ b/app/epa/urls.py
@@ -24,8 +24,8 @@ from .views import imprint, privacy, about, license
 urlpatterns = (
     i18n_patterns(
         path("admin/", admin.site.urls),
-        path("users/", include("users.urls")),
         path("users/", include("django.contrib.auth.urls")),
+        path("users/", include("users.urls")),
         path("", include("projects.urls")),
         path("dashboard/", include("dashboard.urls")),
         path("imprint/", imprint, name="imprint"),

--- a/app/projects/services.py
+++ b/app/projects/services.py
@@ -13,10 +13,7 @@ from exchangelib import (
     Message,
     Mailbox,
 )  # pylint: disable=import-error
-from exchangelib import (
-    EWSTimeZone,
-    Configuration,
-)
+from exchangelib import EWSTimeZone, Configuration
 from requests.exceptions import ConnectionError  # pylint: disable=import-error
 
 from epa.settings import (

--- a/app/templates/registration/acc_active_email.html
+++ b/app/templates/registration/acc_active_email.html
@@ -1,6 +1,10 @@
-{% autoescape off %}  
-Hi {{ user.username }},  
-Please click on the link to confirm your registration,
-http://{{ domain }}{% url 'activate' uidb64=uid token=token %}  
-If you think, it's not you, then just ignore this email.  
+{% load i18n %}
+{% autoescape off %}
+Hi {{ user.username }},
+
+{% trans "Please click on the link to confirm your registration" %},
+
+http://{{ domain }}{% url 'activate' uidb64=uid token=token %}
+
+{% trans "If you think, it's not you, then just ignore this email." %}
 {% endautoescape %}

--- a/app/templates/registration/acc_active_email.html
+++ b/app/templates/registration/acc_active_email.html
@@ -4,7 +4,7 @@
 
 {% trans "Please click on the link to confirm your registration" %},
 
-http://{{ domain }}{% url 'activate' uidb64=uid token=token %}
+https://{{ domain }}{% url 'activate' uidb64=uid token=token %}
 
 {% trans "If you think, it's not you, then just ignore this email." %}
 {% endautoescape %}

--- a/app/templates/registration/acc_active_email.html
+++ b/app/templates/registration/acc_active_email.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% autoescape off %}
-Hi {{ user.username }},
+{% trans "Hi" %} {{ user.username }},
 
 {% trans "Please click on the link to confirm your registration" %},
 

--- a/app/templates/registration/acc_active_email.html
+++ b/app/templates/registration/acc_active_email.html
@@ -4,7 +4,7 @@
 
 {% trans "Please click on the link to confirm your registration" %},
 
-https://{{ domain }}{% url 'activate' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'activate' uidb64=uid token=token %}
 
 {% trans "If you think, it's not you, then just ignore this email." %}
 {% endautoescape %}

--- a/app/users/urls.py
+++ b/app/users/urls.py
@@ -5,8 +5,8 @@ from .views import (
     change_password,
     user_info,
     activate,
-    password_reset_request,
     user_deletion_request,
+    ExchangePasswordResetView,
 )
 
 urlpatterns = [
@@ -14,6 +14,6 @@ urlpatterns = [
     path("change_password/", change_password, name="change_password"),
     path("user_info/", user_info, name="user_info"),
     path("activate/<uidb64>/<token>/", activate, name="activate"),
-    path("password_reset", password_reset_request, name="password_reset"),
+    path("password_reset", ExchangePasswordResetView.as_view(), name="password_reset"),
     path("user_deletion", user_deletion_request, name="user_deletion"),
 ]

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -32,6 +32,7 @@ def signup(request):
             user.save()
             current_site = get_current_site(request)
             subject = _("Activate your account.")
+            protocol = "https" if settings.DEBUG is False else request.scheme
             message = render_to_string(
                 "registration/acc_active_email.html",
                 {
@@ -39,6 +40,7 @@ def signup(request):
                     "domain": current_site.domain,
                     "uid": urlsafe_base64_encode(force_bytes(user.pk)),
                     "token": default_token_generator.make_token(user),
+                    "protocol": protocol,
                 },
             )
             to_email = form.cleaned_data.get("email")
@@ -123,6 +125,9 @@ class ExchangePasswordResetForm(PasswordResetForm):
         subject = render_to_string(subject_template_name, context)
         # Email subject *must not* contain newlines
         subject = "".join(subject.splitlines())
+        # Force the https for the production
+        if settings.DEBUG is False:
+            context["protocol"] = "https"
         message = render_to_string(email_template_name, context)
         send_email_exchange(to_email=to_email, subject=subject, message=message)
 

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -15,7 +15,7 @@ from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_http_methods
 
-from projects.services import send_email
+from projects.services import send_email as send_email_exchange
 from .forms import CustomUserCreationForm, CustomUserChangeForm
 
 DEFAULT_FROM_EMAIL = settings.DEFAULT_FROM_EMAIL
@@ -42,7 +42,7 @@ def signup(request):
                 },
             )
             to_email = form.cleaned_data.get("email")
-            send_email(to_email=to_email, subject=subject, message=message)
+            send_email_exchange(to_email=to_email, subject=subject, message=message)
             messages.info(
                 request,
                 _("Please confirm your email address to complete the registration"),
@@ -122,7 +122,7 @@ class ExchangePasswordResetForm(PasswordResetForm):
         # Email subject *must not* contain newlines
         subject = "".join(subject.splitlines())
         message = render_to_string(email_template_name, context)
-        send_email(to_email=to_email, subject=subject, message=message)
+        send_email_exchange(to_email=to_email, subject=subject, message=message)
 
 
 class ExchangePasswordResetView(PasswordResetView):

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -64,7 +64,9 @@ def activate(request, uidb64, token):
         user.save()
         messages.success(
             request,
-            "Thank you for your email confirmation. Now you can log in your account.",
+            _(
+                "Thank you for your email confirmation. Now you can log in your account."
+            ),
         )
         return redirect("login")
     else:
@@ -79,10 +81,10 @@ def user_info(request):
         form = CustomUserChangeForm(request.POST, instance=request.user)
         if form.is_valid():
             user = form.save()
-            messages.success(request, "User info successfully updated!")
+            messages.success(request, _("User info successfully updated!"))
             return redirect("user_info")
         else:
-            messages.error(request, "Please check errors and resubmit!")
+            messages.error(request, _("Please check errors and resubmit!"))
     else:
         form = CustomUserChangeForm(instance=request.user)
     return render(request, "registration/user_info.html", {"form": form})
@@ -96,10 +98,10 @@ def change_password(request):
         if form.is_valid():
             user = form.save()
             update_session_auth_hash(request, user)  # Important!
-            messages.success(request, "Your password was successfully updated!")
+            messages.success(request, _("Your password was successfully updated!"))
             return redirect("change_password")
         else:
-            messages.error(request, "Please check errors and resubmit!")
+            messages.error(request, _("Please check errors and resubmit!"))
     else:
         form = PasswordChangeForm(request.user)
     return render(request, "registration/change_password.html", {"form": form})

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -5,17 +5,18 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordChangeForm, PasswordResetForm
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.auth.views import PasswordResetView
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.mail import EmailMessage, send_mail, BadHeaderError
-from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
 from django.template.loader import render_to_string
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_http_methods
+
+from projects.services import send_email
 from .forms import CustomUserCreationForm, CustomUserChangeForm
-from .models import CustomUser
 
 DEFAULT_FROM_EMAIL = settings.DEFAULT_FROM_EMAIL
 EMAIL_HOST = settings.EMAIL_HOST
@@ -30,7 +31,7 @@ def signup(request):
             user.is_active = False
             user.save()
             current_site = get_current_site(request)
-            mail_subject = "Activate your account."
+            subject = _("Activate your account.")
             message = render_to_string(
                 "registration/acc_active_email.html",
                 {
@@ -41,11 +42,10 @@ def signup(request):
                 },
             )
             to_email = form.cleaned_data.get("email")
-            email = EmailMessage(mail_subject, message, to=[to_email])
-            email.send()
+            send_email(to_email=to_email, subject=subject, message=message)
             messages.info(
                 request,
-                "Please confirm your email address to complete the registration",
+                _("Please confirm your email address to complete the registration"),
             )
             return redirect("home")
     else:
@@ -64,7 +64,7 @@ def activate(request, uidb64, token):
         user.save()
         messages.success(
             request,
-            "Thank you for your email confirmation. Now you can login your account.",
+            "Thank you for your email confirmation. Now you can log in your account.",
         )
         return redirect("login")
     else:
@@ -105,43 +105,28 @@ def change_password(request):
     return render(request, "registration/change_password.html", {"form": form})
 
 
-def password_reset_request(request):
-    if request.method == "POST":
-        password_reset_form = PasswordResetForm(request.POST)
-        if password_reset_form.is_valid():
-            data = password_reset_form.cleaned_data["email"]
-            associated_users = CustomUser.objects.filter(Q(email=data))
-            if associated_users.exists():
-                for user in associated_users:
-                    subject = "Password Reset Requested"
-                    email_template_name = "registration/password_reset_email.txt"
-                    c = {
-                        "email": user.email,
-                        "domain": EMAIL_HOST,
-                        "site_name": "open_plan",
-                        "uid": urlsafe_base64_encode(force_bytes(user.pk)),
-                        "user": user,
-                        "token": default_token_generator.make_token(user),
-                        "protocol": "http",
-                    }
-                    email = render_to_string(email_template_name, c)
-                    try:
-                        send_mail(
-                            subject,
-                            email,
-                            DEFAULT_FROM_EMAIL,
-                            [user.email],
-                            fail_silently=False,
-                        )
-                    except BadHeaderError:
-                        return HttpResponse("Invalid header found.")
-                    return redirect("/password_reset/done/")
-    password_reset_form = PasswordResetForm()
-    return render(
-        request=request,
-        template_name="registration/password_reset_form.html",
-        context={"password_reset_form": password_reset_form},
-    )
+class ExchangePasswordResetForm(PasswordResetForm):
+    def send_mail(
+        self,
+        subject_template_name,
+        email_template_name,
+        context,
+        from_email,
+        to_email,
+        html_email_template_name=None,
+    ):
+        """
+        Send a django.core.mail.EmailMultiAlternatives to `to_email`.
+        """
+        subject = render_to_string(subject_template_name, context)
+        # Email subject *must not* contain newlines
+        subject = "".join(subject.splitlines())
+        message = render_to_string(email_template_name, context)
+        send_email(to_email=to_email, subject=subject, message=message)
+
+
+class ExchangePasswordResetView(PasswordResetView):
+    form_class = ExchangePasswordResetForm
 
 
 @login_required
@@ -151,5 +136,5 @@ def user_deletion_request(request):
     logout(request)
     user_model = get_user_model()
     user_model.objects.filter(pk=user_pk).delete()
-    messages.info(request, "Your user account has been deleted.")
+    messages.info(request, _("Your user account has been deleted."))
     return redirect("home")


### PR DESCRIPTION
**Edit:** Is based on unmerged #213. Please merge #213 first.

Closes #211.

Hi @Bachibouzouk, please review this PR and merge on approval.

It now uses exchangelib for the whole app and removes all artifacts concerning Django's email integration.

Please note: Because we use exchangelib now on all occasions, we always have to overwrite Django class methods in which Django sends an email with our own implementation in `app/projects/services.py:send_email.` For example, Django's generic PasswordResetView (PasswordResetForm). Which I have overwritten in `app/users/views.py:ExchangePasswordResetView`.