### PR TITLE
Set max simulation time

### DIFF
--- a/app/projects/requests.py
+++ b/app/projects/requests.py
@@ -105,6 +105,13 @@ def fetch_mvs_simulation_results(simulation):
             simulation.results = None
 
         simulation.elapsed_seconds = (datetime.now() - simulation.start_date).seconds
+
+        # Cancel simulation if it has been going on > 48h
+        max_simulation_seconds = 48 * 60 * 60
+        if simulation.elapsed_seconds > max_simulation_seconds:
+            simulation.status = ERROR
+            simulation.results = None
+
         simulation.end_date = (
             datetime.now() if simulation.status in [ERROR, DONE] else None
         )


### PR DESCRIPTION
Some simulations seem to keep the status "PENDING" forever, which means that the server would check them periodically, even if they were long gone from the queue. It seems that the checking of these optimization might have been causing performance issues with the simulation server. To circumvent these issues, we should abort the calculation after a certain amount of time (tbd)