### PR TITLE
Implement check to avoid starting a simulation with unconnected components

### DIFF
--- a/app/static/js/grid_model_topology.js
+++ b/app/static/js/grid_model_topology.js
@@ -747,3 +747,44 @@ function computeCOP(event){
         alert(error.message);
     });
 }
+
+
+function validateNodeConnections(editor) {
+    const nodes = editor.export().drawflow.Home.data;
+
+    for (const nodeId in nodes) {
+        const node = nodes[nodeId];
+        const name = node.name; // "...-demand", "bus--...", sources are the rest
+        let inputCount = 0;
+        let outputCount = 0;
+
+        for (const inputName in node.inputs) {
+            inputCount += node.inputs[inputName].connections.length;
+        }
+        for (const outputName in node.outputs) {
+            outputCount += node.outputs[outputName].connections.length;
+        }
+        // Sink
+        if (name.endsWith("demand")) {
+            if (inputCount < 1) {
+                alert(`Sink "${node.data.name}" must have at least 1 input.`);
+                return false;
+            }
+            continue;
+        }
+        // Bus
+        if (name.startsWith("bus--")) {
+            if (inputCount < 1 || outputCount < 1) {
+                alert(`Bus "${node.data.name}" must have at least 1 input AND 1 output.`);
+                return false;
+            }
+            continue;
+        }
+        // Source
+        if (outputCount < 1) {
+            alert(`Source "${node.data.name}" must have at least 1 output.`);
+            return false;
+        }
+    }
+    return true;
+}

--- a/app/static/js/grid_model_topology.js
+++ b/app/static/js/grid_model_topology.js
@@ -773,7 +773,7 @@ function validateNodeConnections(editor) {
             continue;
         }
         // Bus
-        if (name.startsWith("bus--")) {
+        if (name.startsWith("bus")) {
             if (inputCount < 1 || outputCount < 1) {
                 alert(`Bus "${node.data.name}" must have at least 1 input AND 1 output.`);
                 return false;

--- a/app/templates/scenario/scenario_step2.html
+++ b/app/templates/scenario/scenario_step2.html
@@ -217,6 +217,12 @@
         // warn in case of empty model
         if (node_list.length == 0 && !confirm('No components in model. Continue?'))
             return;
+        // Check that all nodes are connected to at least one bus
+        if (!validateNodeConnections(editor)) {
+            console.log("connections are false")
+            return;
+        }
+
         // Check if there are duplicate node names in the model
         // and prevent user from saving the model if there are.
         // Might also be handled in backend when saving names.


### PR DESCRIPTION
added js check to see if the nodes are connected before saving

Since I solved this on the client Side the nodes don't know what kind of type they are and I needed to base the validation of of their names. Right now I have implemented the validation with this logic:

- name that starts with "bus": need to have at least 1 input and 1 output
- name that ends with "demand": need to have at least 1 input
- the rest (which I think are mostly sources): need to have at least

I am not sure if like Conversion nodes need to be handled differently, but more diverse checks could be implemented. 