### PR TITLE
Fix MultipleObjectsReturned error on import

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fix project import error caused by duplicate timeseries
 
 ## [v2.0.0] – 2026-01-12
 ### Added

--- a/app/projects/scenario_topology_helpers.py
+++ b/app/projects/scenario_topology_helpers.py
@@ -631,6 +631,7 @@ def load_scenario_from_dict(model_data, user, project=None):
                         input_timeseries[k] = datetime.datetime.strptime(
                             input_timeseries[k], "%Y-%m-%d %H:%M:%S"
                         )
+                input_timeseries["scenario"] = scenario
                 input_ts, created = Timeseries.objects.get_or_create(
                     user=user, **input_timeseries
                 )


### PR DESCRIPTION
When importing a project, the tool was checking if an identical timeseries (`values`, `name`) already exists, but not considering `scenario`. That was throwing a `MultipleObjectsReturned` for duplicated timeseries across different scenarios. This fix differentiates timeseries by scenario, but with the consequence that it will likely produce more duplicate timeseries across scenarios. That also means that the timeseries widget will offer multiple identical timeseries with the current implementation. 

It needs to be part of a larger conversation about timeseries management how we want to go about timeseries, especially having the drop down widget. 
- Should the timeseries selected be linked to multiple scenarios, or should a duplicate be created?
- If the timeseries is changed for one scenario, should that change happen across all scenarios or just the one?
- If a user deletes a timeseries, is it deleted for just the scenario or for all it is used in?
- Should the drop down widget filter by project or show all timeseries belonging to the user as it is now?
- What should be the implementation of the timeseries admin site? Can the user upload timeseries here directly to then use on projects?
- etc etc...