### PR TITLE
Handle DualNumberFields correctly in asset change tracker

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix project import error caused by duplicate timeseries.
 - Fix energy system design window snapping on drag.
 - Fix YouTube redirection link.
+- Fix field validation error on heat storage.
 
 ## [v2.0.0] – 2026-01-12
 ### Added

--- a/app/projects/scenario_topology_helpers.py
+++ b/app/projects/scenario_topology_helpers.py
@@ -1,6 +1,8 @@
 import uuid
 import numpy as np
 import datetime
+
+from django.forms import MultiValueField
 from django.shortcuts import get_object_or_404
 from projects.models import (
     Bus,
@@ -116,7 +118,7 @@ def track_asset_changes(scenario, param, form, existing_asset, new_value=None):
                 if pi.parameter_type == "vector":
                     old_value = (old_value, None)
 
-                if pi.name == "input_timeseries":
+                if isinstance(form.fields[pi.name], MultiValueField):
                     new_value = str(new_value)
                 else:
                     old_value = form.fields[pi.name].clean(old_value)


### PR DESCRIPTION
In their own `clean` methods, `DualNumberFields` (both Timeseries and some efficiency fields) already unpack the input values to differentiate between vector and scalar inputs, returning only one of the values. When tracking field changes, some of these fields were being re-cleaned, returning a `too many values to unpack` error.