### PR TITLE
Add requirements for oemof-datapackage

### DIFF
--- a/app/requirements/base.txt
+++ b/app/requirements/base.txt
@@ -18,5 +18,6 @@ openpyxl==3.0.10
 plotly==5.6.0
 psycopg2-binary==2.9.3
 requests==2.24.0
+toml
 whitenoise==6.9.0
 XlsxWriter==1.3.9

--- a/app/requirements/base.txt
+++ b/app/requirements/base.txt
@@ -17,7 +17,7 @@ oemof-thermal==0.0.8
 openpyxl==3.0.10
 plotly==5.6.0
 psycopg2-binary==2.9.3
-requests==2.24.0
+requests>=2.24.0
 toml
 whitenoise==6.9.0
 XlsxWriter==1.3.9


### PR DESCRIPTION
As oemof-datapackage is currently not released yet some dependencies were not automatically installed. This will likely be solved by an oemof-datapackage release