### PR TITLE
Set simulation queue from environment variable

### DIFF
--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -208,8 +208,11 @@ PROXY_CONFIG = (
     else (dict())
 )
 
+# Server queue which will process the simulation, openplan for prod mvs version and "" (blank) for dev mvs version
+MVS_API_QUEUE = env("MVS_API_QUEUE", default="openplan")
+
 MVS_API_HOST = env("MVS_API_HOST", default="https://mvs-eland.rl-institut.de")
-MVS_POST_URL = f"{MVS_API_HOST}/sendjson/"
+MVS_POST_URL = f"{MVS_API_HOST}/sendjson/{MVS_API_QUEUE}"
 MVS_GET_URL = f"{MVS_API_HOST}/check/"
 MVS_LP_FILE_URL = f"{MVS_API_HOST}/get_lp_file/"
 MVS_SA_POST_URL = f"{MVS_API_HOST}/sendjson/openplan/sensitivity-analysis"


### PR DESCRIPTION
I again split the simulation server queue into two:
- prod aka `sendjson/openplan`, which currently simulates on mvs 1.0.7rc3
- dev aka `sendjson/`, which currently simulates on mvs 1.0.6rc26

To handle this more easily on the staging / production setups, I added an environment variable so that we can easily send the simulations on the staging server to dev and on production server to prod without having to change the settings file, only through the `MVS_API_QUEUE` set on caprover.