### PR TITLE
Fix GET method not allowed on logout

### DIFF
--- a/app/projects/tests.py
+++ b/app/projects/tests.py
@@ -148,6 +148,11 @@ class BasicOperationsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "scenario/scenario_step1.html")
 
+    def test_logout(self):
+        response = self.client.post(reverse("logout"), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "index.html")
+
 
 class ExportLoadTest(TestCase):
     fixtures = ["fixtures/benchmarks_fixture.json"]

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -89,7 +89,12 @@
 						<li><a class="dropdown-item" href="{% url 'user_info' %}">{% translate "Account" %}</a></li> <!-- account.html -->
 						<li><a class="dropdown-item" href="{% url 'license' %}">{% translate "License" %}</a></li>
 						<li><hr class="dropdown-divider"></li>
-						<li><a class="dropdown-item" href="{% url 'logout' %}">{% translate "Log out" %}</a></li>
+						<li>
+							<form method="post" action="{% url 'logout' %}">
+								{% csrf_token %}
+								<button class="dropdown-item" type="submit">{% translate "Log out" %}</button>
+							</form>
+						</li>
 					</ul>
 				</li>
 				{% else %}


### PR DESCRIPTION
This fixes the broken logout button after the Django upgrade. Using logout with GET was deprecated for security reasons https://forum.djangoproject.com/t/deprecation-of-get-method-for-logoutview/25533.