### PR TITLE
Remove unwanted slashes from directory name

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fix datapackage export if scenario name contains slashes [[#455](https://github.com/open-plan-tool/gui/pull/455)]
 
 ## [v2.1.0] – 2026-04-14
 ### Added

--- a/app/projects/models/base_models.py
+++ b/app/projects/models/base_models.py
@@ -326,8 +326,19 @@ class Scenario(models.Model):
         -------
         A Path to the scenario datapackage
         """
+
         # Create a folder with a datapackage structure
-        scenario_folder = destination_path / f"scenario_{self.name}".replace(" ", "_")
+        def clean_dir_str(name):
+            # Remove spaces and slashes (can accidentally lead to subdirectories in datapackage)
+            bad_chars = [" ", "/", "\\"]
+            for char in bad_chars:
+                name = name.replace(char, "_")
+
+            return name
+
+        clean_dir_name = clean_dir_str(self.name)
+
+        scenario_folder = destination_path / f"scenario_{clean_dir_name}"
 
         data_folder = scenario_folder / "data"
         elements_folder = data_folder / "elements"


### PR DESCRIPTION
Slashes in the scenario names (which is the case for some of the use cases) was causing the Path commands to accidentally include subdirectories when trying to split the string, so now all slashes are replaced with underscores.