### PR TITLE
Fix aggregated results not displaying on Chrome

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix thermal efficiency value display for heat storage on results page [[#451](https://github.com/open-plan-tool/gui/pull/451)]
 - Small usability improvements like additional support messages or fixed translations [[#457](https://github.com/open-plan-tool/gui/pull/457)]
 - Remove faulty KPIs from results view [[#457](https://github.com/open-plan-tool/gui/pull/457)]
+- Fix certain fields in results display appearing blank for Chromium browsers [[#461](https://github.com/open-plan-tool/gui/pull/461)]
 
 ## [v2.1.1] – 2026-04-15
 ### Fixed

--- a/app/templates/asset/asset_create_form.html
+++ b/app/templates/asset/asset_create_form.html
@@ -18,7 +18,7 @@
                 <label for="id_optimized_add_cap">
                 {% translate "Optimized additional capacity" %} ({{ optimized_add_cap|get_item:'unit' }})
                 </label>
-                <input readonly type="number" name="optimized_add_cap" value="{{ optimized_add_cap|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_optimized_add_cap" data-bs-original-title="TBD" aria-label="TDB">
+                <input readonly name="optimized_add_cap" value="{{ optimized_add_cap|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_optimized_add_cap" data-bs-original-title="TBD" aria-label="TDB">
               </div>
               {% endif %}
                 {% if total_flow %}
@@ -27,7 +27,7 @@
 		                  <label for="id_total_flow">
 		                  {% translate "Aggregated flow" %} {{aggregated_flow|get_item:'label'}} ({{ aggregated_flow|get_item:'unit' }})
 		                  </label>
-									    <input readonly type="number" name="total_flow" value="{{ aggregated_flow|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_total_flow" data-bs-original-title="TBD" aria-label="TDB">
+									    <input readonly name="total_flow" value="{{ aggregated_flow|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_total_flow" data-bs-original-title="TBD" aria-label="TDB">
 	                  </div>
 				      {% endfor %}
               {% endif %}

--- a/app/templates/asset/storage_asset_create_form.html
+++ b/app/templates/asset/storage_asset_create_form.html
@@ -17,7 +17,7 @@
                 Optimized additional capacity ({{ optimized_add_cap|get_item:'unit' }})
                 </label>
 
-                <input readonly type="number" name="optimized_add_cap" value="{{ optimized_add_cap|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_optimized_add_cap" data-bs-original-title="TBD" aria-label="TDB">
+                <input readonly name="optimized_add_cap" value="{{ optimized_add_cap|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_optimized_add_cap" data-bs-original-title="TBD" aria-label="TDB">
               </div>
               {% endif %}
 							{% if total_flow %}
@@ -26,7 +26,7 @@
 									<label for="id_total_flow">
 									{% translate "Aggregated flow" %} {{aggregated_flow|get_item:'label'}} ({{ aggregated_flow|get_item:'unit' }})
 									</label>
-									<input readonly type="number" name="total_flow" value="{{ aggregated_flow|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_total_flow" data-bs-original-title="TBD" aria-label="TDB">
+									<input readonly name="total_flow" value="{{ aggregated_flow|get_item:'value' }}" min="0.0"  data-bs-toggle="tooltip" title="" style="font-weight:400; font-size:13px;" class="view-only numberinput form-control form-control" required="" id="id_total_flow" data-bs-original-title="TBD" aria-label="TDB">
 								</div>
 							{% endfor %}
               {% endif %}


### PR DESCRIPTION
Fixes #418. Apparently, Chromium is a lot more strict with `input_type="number"` and will parse as invalid if the value uses comma as a decimal separator, which was causing some numbers to not display in the result assets when clicking them open.

As the values are just meant for checking and readonly, it seems fine to just remove the `input_type` constraint from the fields, which allows the numbers to be displayed.

Interestingly, this issue was only happening when using the german version of open plan (`/de` locale), because here the decimal separator gets parsed as a comma. When using `/en`, the decimal separator is a point and did not cause any issues in the display. 