### PR TITLE
Move redis back into base requirements

### DIFF
--- a/app/requirements/base.txt
+++ b/app/requirements/base.txt
@@ -9,6 +9,7 @@ django-jsonview==2.0.0
 django-sass-processor==1.4.2
 django-celery-beat==2.9.0
 flower==2.0.1
+redis==7.4.0
 git+https://github.com/oemof/oemof-datapackage.git@dev
 httpx<0.28
 jsonschema==4.26.0

--- a/app/requirements/local.txt
+++ b/app/requirements/local.txt
@@ -5,4 +5,3 @@ django-environ==0.12.0
 pre-commit==4.5.1
 
 pytest==9.0.2
-redis==7.4.0


### PR DESCRIPTION
Celery functions use redis dependency, so it breaks if not installed in production