### PR TITLE
Fix display on LCOE and percentage values

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Changed
 - Remove specific workshop dates from courses site (will be redirected to DGS instead) [[#475](https://github.com/open-plan-tool/gui/pull/475)]
 
+### Fixed
+- Fix display on LCOE and percentage values [[#476](https://github.com/open-plan-tool/gui/pull/476)]
 
 ## [v2.1.2] – 2026-05-13
 ### Fixed

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -701,6 +701,8 @@ def request_kpi_table(request, proj_id=None):
                         break
 
                     if param["unit"] == "%":
+                        values.append(beautify_number(val * 100, 0))
+                    elif f"{proj.economic_data.currency}/kWh" in param["unit"]:
                         values.append(beautify_number(val, 2))
                     else:
                         values.append(beautify_number(val, 0))


### PR DESCRIPTION
Percentage was being displayed as decimal, and LCOE was disappearing completely due to being rounded to an integer.