### PR TITLE
Fix validation error for constant value input in timeseries field

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Update incorrect or missing translation strings [[#480](https://github.com/open-plan-tool/gui/pull/480)]
+- Fix validation error bug on timeseries with constant value [[#486](https://github.com/open-plan-tool/gui/pull/486)]
 
 ## [v2.1.3] – 2026-05-20
 ### Changed

--- a/app/projects/forms.py
+++ b/app/projects/forms.py
@@ -967,14 +967,11 @@ class AssetCreateForm(OpenPlanModelForm):
             if input_method == TS_UPLOAD_TYPE or input_method == TS_MANUAL_TYPE:
                 # replace the dict with a new timeseries instance
                 timeseries_obj = self.assign_timeseries_from_input(ts_data)
-                num_timestamps = self.scenario.get_num_timesteps
-                if len(timeseries_obj.values) != num_timestamps:
-                    msg = _(
-                        f"The length of the timeseries ({len(timeseries_obj.values)}) does not match the lentgh of the selected timesteps ({num_timestamps}). You can check your timeseries file or change the timesteps in step 1."
+                if input_method == TS_UPLOAD_TYPE:
+                    self.timeseries_same_as_timestamps(
+                        timeseries_obj.values, "input_timeseries"
                     )
-                    self.add_error("input_timeseries", msg)
-                else:
-                    cleaned_data["input_timeseries"] = timeseries_obj
+                cleaned_data["input_timeseries"] = timeseries_obj
             if input_method == TS_SELECT_TYPE:
                 # return the timeseries instance
                 timeseries_id = ts_data["input_method"]["extra_info"]

--- a/app/projects/tests.py
+++ b/app/projects/tests.py
@@ -435,7 +435,18 @@ class UploadTimeseriesTest(TestCase):
             response = self.client.post(self.post_url, data, format="multipart")
             form = response.context["form"]
             self.assertIn("input_timeseries", form.errors)
-            self.assertIn(
-                "does not match the lentgh", str(form.errors["input_timeseries"])
-            )
             self.assertEqual(response.status_code, 422)
+
+    def test_scalar_timeseries(self):
+        data = {
+            "name": "Test_input_timeseries",
+            "pos_x": 0,
+            "pos_y": 0,
+            "input_timeseries_scalar": 1,
+            "input_timeseries_select": "",
+            "input_timeseries_file": "",
+        }
+        response = self.client.post(self.post_url, data, format="multipart")
+        asset = Asset.objects.last()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(asset.input_timeseries_values, [1])


### PR DESCRIPTION
Fixes #482. Code was checking all timeseries regardless of input type, falsely labeling constants as having the wrong lengths. Also removed individual check/error message in favor of reusing established `timeseries_same_as_timestamps` validation method.