### PR TITLE
Add toggle switch boolean fields

### DIFF
--- a/app/locale/de/LC_MESSAGES/django.po
+++ b/app/locale/de/LC_MESSAGES/django.po
@@ -1023,6 +1023,9 @@ msgstr "Wirtschaftliche Parameter"
 msgid "Technical parameters"
 msgstr "Technische Parameter"
 
+msgid "Settings"
+msgstr "Einstellungen"
+
 #: templates/asset/asset_create_form.html:68
 msgid "Calculate COP from temperature"
 msgstr "COP aus Temperatur berechnen"

--- a/app/projects/forms.py
+++ b/app/projects/forms.py
@@ -701,19 +701,7 @@ class ToggleSwitchWidget(forms.CheckboxInput):
     def render(self, name, value, attrs=None, renderer=None):
         checkbox_html = super().render(name, value, attrs, renderer)
         return format_html(
-            """
-            <style>
-              .toggle-switch {{ position: relative; display: inline-block; width: 48px; height: 24px; }}
-              .toggle-switch input {{ opacity: 0; width: 0; height: 0; }}
-              .toggle-slider {{ position: absolute; cursor: pointer; inset: 0;
-                background-color: #ccc; border-radius: 24px; transition: 0.3s; }}
-              .toggle-slider::before {{ content: ""; position: absolute; height: 18px; width: 18px;
-                left: 3px; bottom: 3px; background-color: white; border-radius: 50%; transition: 0.3s; }}
-              .toggle-switch input:checked + .toggle-slider {{ background-color: #1F567D; }}
-              .toggle-switch input:checked + .toggle-slider::before {{ transform: translateX(24px); }}
-            </style>
-            <label class="toggle-switch">{}<span class="toggle-slider"></span></label>
-            """,
+            '<label class="toggle-switch">{}<span class="toggle-slider"></span></label>',
             checkbox_html,
         )
 

--- a/app/projects/forms.py
+++ b/app/projects/forms.py
@@ -694,6 +694,30 @@ class BusForm(OpenPlanModelForm):
         labels = {"name": _("Name"), "type": _("Energy carrier")}
 
 
+class ToggleSwitchWidget(forms.CheckboxInput):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def render(self, name, value, attrs=None, renderer=None):
+        checkbox_html = super().render(name, value, attrs, renderer)
+        return format_html(
+            """
+            <style>
+              .toggle-switch {{ position: relative; display: inline-block; width: 48px; height: 24px; }}
+              .toggle-switch input {{ opacity: 0; width: 0; height: 0; }}
+              .toggle-slider {{ position: absolute; cursor: pointer; inset: 0;
+                background-color: #ccc; border-radius: 24px; transition: 0.3s; }}
+              .toggle-slider::before {{ content: ""; position: absolute; height: 18px; width: 18px;
+                left: 3px; bottom: 3px; background-color: white; border-radius: 50%; transition: 0.3s; }}
+              .toggle-switch input:checked + .toggle-slider {{ background-color: #1F567D; }}
+              .toggle-switch input:checked + .toggle-slider::before {{ transform: translateX(24px); }}
+            </style>
+            <label class="toggle-switch">{}<span class="toggle-slider"></span></label>
+            """,
+            checkbox_html,
+        )
+
+
 class AssetCreateForm(OpenPlanModelForm):
     def __init__(self, *args, **kwargs):
         self.asset_type_name = kwargs.pop("asset_type", None)
@@ -1033,9 +1057,9 @@ class AssetCreateForm(OpenPlanModelForm):
         model = Asset
         exclude = ["scenario"]
         widgets = {
-            "optimize_cap": forms.Select(choices=BOOL_CHOICES),
-            "dispatchable": forms.Select(choices=TRUE_FALSE_CHOICES),
-            "renewable_asset": forms.Select(choices=BOOL_CHOICES),
+            "optimize_cap": ToggleSwitchWidget(),
+            "dispatchable": ToggleSwitchWidget(),
+            "renewable_asset": ToggleSwitchWidget(),
             "name": forms.TextInput(
                 attrs={
                     "placeholder": _("Asset Name"),

--- a/app/projects/forms.py
+++ b/app/projects/forms.py
@@ -941,6 +941,14 @@ class AssetCreateForm(OpenPlanModelForm):
                     ),
                 )
 
+        # If optimize capacity is selected, set the installed capacity and age to zero (as they are explicitly hidden in the form but might contain old values)
+        # otherwise reset maximum capacity instead
+        if cleaned_data["optimize_cap"]:
+            cleaned_data["age_installed"] = 0
+            cleaned_data["installed_capacity"] = 0.0
+        else:
+            cleaned_data["maximum_capacity"] = None
+
         if self.asset_type_name == "heat_pump":
             if "efficiency" not in self.errors:
                 efficiency = cleaned_data["efficiency"]

--- a/app/projects/forms.py
+++ b/app/projects/forms.py
@@ -943,11 +943,12 @@ class AssetCreateForm(OpenPlanModelForm):
 
         # If optimize capacity is selected, set the installed capacity and age to zero (as they are explicitly hidden in the form but might contain old values)
         # otherwise reset maximum capacity instead
-        if cleaned_data["optimize_cap"]:
-            cleaned_data["age_installed"] = 0
-            cleaned_data["installed_capacity"] = 0.0
-        else:
-            cleaned_data["maximum_capacity"] = None
+        if "optimize_cap" in cleaned_data:
+            if cleaned_data["optimize_cap"]:
+                cleaned_data["age_installed"] = 0
+                cleaned_data["installed_capacity"] = 0.0
+            else:
+                cleaned_data["maximum_capacity"] = None
 
         if self.asset_type_name == "heat_pump":
             if "efficiency" not in self.errors:

--- a/app/projects/templatetags/custom_filters.py
+++ b/app/projects/templatetags/custom_filters.py
@@ -79,6 +79,16 @@ def has_field(form, key):
 
 
 @register.filter
+def has_toggle_parameters(form):
+    answer = False
+    for field in form.fields:
+        if is_toggle_parameter(field):
+            answer = True
+            break
+    return answer
+
+
+@register.filter
 def has_economical_parameters(form):
     answer = False
     for field in form.fields:
@@ -99,6 +109,11 @@ def has_technical_parameters(form):
 
 
 @register.filter
+def is_toggle_parameter(param):
+    return param in ["optimize_cap", "dispatchable", "renewable_asset"]
+
+
+@register.filter
 def is_economical_parameter(param):
     return param in [
         "capex_fix",
@@ -114,8 +129,9 @@ def is_economical_parameter(param):
 def is_technical_parameter(param):
     if param == "name":
         return False
-    else:
-        return not is_economical_parameter(param)
+    if is_toggle_parameter(param):
+        return False
+    return not is_economical_parameter(param)
 
 
 @register.filter

--- a/app/projects/tests.py
+++ b/app/projects/tests.py
@@ -5,7 +5,7 @@ import pytest
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
-from projects.models import Project, Scenario, Asset
+from projects.models import Project, Scenario, Asset, AssetType
 from projects.scenario_topology_helpers import (
     load_scenario_from_dict,
     load_project_from_dict,
@@ -538,3 +538,114 @@ class UploadTimeseriesTest(TestCase):
         asset = Asset.objects.last()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(asset.input_timeseries_values, [1])
+
+
+class OptimizeCapacityToggleTest(TestCase):
+    """optimize_cap toggle should zero out installed_capacity/age_installed
+    when turned on, and reset maximum_capacity when turned off (forms.py
+    AssetCreateForm.clean)."""
+
+    fixtures = ["fixtures/benchmarks_fixture.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        pass
+
+    def setUp(self):
+        self.client.login(username="testUser", password="ASas12,.")
+        self.project = Project.objects.get(id=1)
+        self.scenario = self.project.scenario_set.first()
+
+        # the fixture predates "maximum_capacity" being added to this asset
+        # type's visible fields, add it so both branches of the toggle can
+        # be exercised
+        self.asset_type = AssetType.objects.get(asset_type="transformer_station_in")
+        self.asset_type.add_field("maximum_capacity")
+        self.asset_type.save()
+
+        self.post_url = reverse(
+            "asset_create_or_update",
+            args=[self.scenario.id, "transformer_station_in"],
+        )
+
+    def asset_data(self, **overrides):
+        data = {
+            "name": "Toggle test asset",
+            "pos_x": 0,
+            "pos_y": 0,
+            "age_installed": 5,
+            "installed_capacity": 50,
+            "capex_fix": 1000,
+            "capex_var": 10,
+            "opex_fix": 5,
+            "opex_var": 2,
+            "lifetime": 10,
+            "efficiency": 0.98,
+            "maximum_capacity": 100,
+        }
+        data.update(overrides)
+        return data
+
+    def test_enabling_optimize_cap_resets_installed_capacity_and_age(self):
+        response = self.client.post(self.post_url, self.asset_data(optimize_cap="true"))
+        self.assertEqual(response.status_code, 200)
+
+        asset = Asset.objects.get(unique_id=response.json()["asset_id"])
+        self.assertTrue(asset.optimize_cap)
+        self.assertEqual(asset.installed_capacity, 0.0)
+        self.assertEqual(asset.age_installed, 0)
+        # maximum_capacity is the optimization bound, kept as submitted
+        self.assertEqual(asset.maximum_capacity, 100.0)
+
+    def test_disabling_optimize_cap_resets_maximum_capacity(self):
+        response = self.client.post(
+            self.post_url, self.asset_data()
+        )  # optimize_cap omitted -> False
+        self.assertEqual(response.status_code, 200)
+
+        asset = Asset.objects.get(unique_id=response.json()["asset_id"])
+        self.assertFalse(asset.optimize_cap)
+        self.assertIsNone(asset.maximum_capacity)
+        self.assertEqual(asset.installed_capacity, 50.0)
+        self.assertEqual(asset.age_installed, 5.0)
+
+    def test_toggling_optimize_cap_on_clears_existing_capacity_and_age_on_update(self):
+        create_response = self.client.post(self.post_url, self.asset_data())
+        asset_uuid = create_response.json()["asset_id"]
+        # reverse() can't place asset_uuid into this route's nested optional
+        # group, so append it to the uuid-less URL instead
+        update_url = f"{self.post_url}/{asset_uuid}"
+
+        response = self.client.post(
+            update_url, self.asset_data(optimize_cap="true", maximum_capacity=200)
+        )
+        self.assertEqual(response.status_code, 200)
+
+        asset = Asset.objects.get(unique_id=asset_uuid)
+        self.assertTrue(asset.optimize_cap)
+        self.assertEqual(asset.installed_capacity, 0.0)
+        self.assertEqual(asset.age_installed, 0)
+        self.assertEqual(asset.maximum_capacity, 200.0)
+
+    def test_toggling_optimize_cap_off_clears_maximum_capacity_on_update(self):
+        create_response = self.client.post(
+            self.post_url, self.asset_data(optimize_cap="true")
+        )
+        asset_uuid = create_response.json()["asset_id"]
+        # reverse() can't place asset_uuid into this route's nested optional
+        # group, so append it to the uuid-less URL instead
+        update_url = f"{self.post_url}/{asset_uuid}"
+
+        response = self.client.post(
+            update_url,
+            self.asset_data(
+                installed_capacity=30, age_installed=3, maximum_capacity=999
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+
+        asset = Asset.objects.get(unique_id=asset_uuid)
+        self.assertFalse(asset.optimize_cap)
+        self.assertIsNone(asset.maximum_capacity)
+        self.assertEqual(asset.installed_capacity, 30.0)
+        self.assertEqual(asset.age_installed, 3.0)

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1189,6 +1189,37 @@ form .form-check-input:focus {
 form .form-check-input:checked {
   background-color: #1F567D; }
 
+form .toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px; }
+  form .toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0; }
+  form .toggle-switch .toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background-color: #E3EAEE;
+    border-radius: 24px;
+    transition: 0.3s; }
+    form .toggle-switch .toggle-slider::before {
+      content: "";
+      position: absolute;
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background-color: #fff;
+      border-radius: 50%;
+      transition: 0.3s; }
+  form .toggle-switch input:checked + .toggle-slider {
+    background-color: #1F567D; }
+    form .toggle-switch input:checked + .toggle-slider::before {
+      transform: translateX(24px); }
+
 form .form-group {
   margin-bottom: 1rem;
   color: #343434; }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1176,134 +1176,134 @@ a.dropdown-item:active {
         padding-left: 0; } }
 /* ----------------------------- open_plan 2 ----------------------------- */
 /* ----------------------------- open_plan 2 ----------------------------- */
-form .form-control:focus {
-  border-color: #1F567D;
-  box-shadow: 0 0 0 0.25rem rgba(31, 86, 125, 0.1); }
+form {
+  /*  .toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 48px;
+    height: 24px;
 
-form .asteriskField {
-  display: none; }
+    input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
 
-form .form-check-input:focus {
-  box-shadow: 0 0 0 0.25rem rgba(31, 86, 125, 0.1); }
-
-form .form-check-input:checked {
-  background-color: #1F567D; }
-
-form .toggle-switch {
-  position: relative;
-  display: inline-block;
-  width: 48px;
-  height: 24px; }
-  form .toggle-switch input {
-    opacity: 0;
-    width: 0;
-    height: 0; }
-  form .toggle-switch .toggle-slider {
-    position: absolute;
-    cursor: pointer;
-    inset: 0;
-    background-color: #E3EAEE;
-    border-radius: 24px;
-    transition: 0.3s; }
-    form .toggle-switch .toggle-slider::before {
-      content: "";
+    .toggle-slider {
       position: absolute;
-      height: 18px;
-      width: 18px;
-      left: 3px;
-      bottom: 3px;
-      background-color: #fff;
-      border-radius: 50%;
-      transition: 0.3s; }
-  form .toggle-switch input:checked + .toggle-slider {
+      cursor: pointer;
+      inset: 0;
+      background-color: $primary-gray-color-2;
+      border-radius: 24px;
+      transition: 0.3s;
+
+      &::before {
+        content: "";
+        position: absolute;
+        height: 18px;
+        width: 18px;
+        left: 3px;
+        bottom: 3px;
+        background-color: $white;
+        border-radius: 50%;
+        transition: 0.3s;
+      }
+    }
+
+    input:checked + .toggle-slider {
+      background-color: $primary-color-1;
+
+      &::before {
+        transform: translateX(24px);
+      }
+    }
+  }
+*/ }
+  form .form-control:focus {
+    border-color: #1F567D;
+    box-shadow: 0 0 0 0.25rem rgba(31, 86, 125, 0.1); }
+  form .asteriskField {
+    display: none; }
+  form .form-check-input:focus {
+    box-shadow: 0 0 0 0.25rem rgba(31, 86, 125, 0.1); }
+  form .form-check-input:checked {
     background-color: #1F567D; }
-    form .toggle-switch input:checked + .toggle-slider::before {
-      transform: translateX(24px); }
-
-form .form-group {
-  margin-bottom: 1rem;
-  color: #343434; }
-  form .form-group label {
-    margin-bottom: 0.5rem; }
-  form .form-group.input-updated {
+  form .form-group {
+    margin-bottom: 1rem;
+    color: #343434; }
+    form .form-group label {
+      margin-bottom: 0.5rem; }
+    form .form-group.input-updated {
+      position: relative;
+      background-color: #FFF9EB;
+      border-color: #FDC534;
+      border-width: 2px;
+      background-image: url("/static/assets/icons/i_edit_yellow.svg");
+      background-position: center right;
+      background-repeat: no-repeat;
+      background-size: auto 1rem; }
+      form .form-group.input-updated:focus {
+        box-shadow: 0 0 0.5rem rgba(253, 197, 52, 0.8); }
+  form .form-control {
+    color: #343434; }
+    form .form-control.input-updated {
+      position: relative;
+      background-color: #FFF9EB;
+      border-color: #FDC534;
+      border-width: 2px;
+      background-image: url("/static/assets/icons/i_edit_yellow.svg");
+      background-position: center right;
+      background-repeat: no-repeat;
+      background-size: auto 1rem; }
+      form .form-control.input-updated:focus {
+        box-shadow: 0 0 0.5rem rgba(253, 197, 52, 0.8); }
+  form .form-control::placeholder {
+    color: #D6D6D6;
+    font-size: 1rem; }
+  form .form-control::-webkit-input-placeholder {
+    color: #D6D6D6;
+    font-size: 1rem; }
+  form .form-control::-moz-placeholder {
+    color: #D6D6D6;
+    font-size: 1rem; }
+  form .form-control:-ms-input-placeholder {
+    color: #D6D6D6;
+    font-size: 1rem; }
+  form .form-control:-moz-placeholder {
+    color: #D6D6D6;
+    font-size: 1rem; }
+  form .input-item,
+  form .text-item {
     position: relative;
-    background-color: #FFF9EB;
-    border-color: #FDC534;
-    border-width: 2px;
-    background-image: url("/static/assets/icons/i_edit_yellow.svg");
-    background-position: center right;
-    background-repeat: no-repeat;
-    background-size: auto 1rem; }
-    form .form-group.input-updated:focus {
-      box-shadow: 0 0 0.5rem rgba(253, 197, 52, 0.8); }
-
-form .form-control {
-  color: #343434; }
-  form .form-control.input-updated {
-    position: relative;
-    background-color: #FFF9EB;
-    border-color: #FDC534;
-    border-width: 2px;
-    background-image: url("/static/assets/icons/i_edit_yellow.svg");
-    background-position: center right;
-    background-repeat: no-repeat;
-    background-size: auto 1rem; }
-    form .form-control.input-updated:focus {
-      box-shadow: 0 0 0.5rem rgba(253, 197, 52, 0.8); }
-
-form .form-control::placeholder {
-  color: #D6D6D6;
-  font-size: 1rem; }
-
-form .form-control::-webkit-input-placeholder {
-  color: #D6D6D6;
-  font-size: 1rem; }
-
-form .form-control::-moz-placeholder {
-  color: #D6D6D6;
-  font-size: 1rem; }
-
-form .form-control:-ms-input-placeholder {
-  color: #D6D6D6;
-  font-size: 1rem; }
-
-form .form-control:-moz-placeholder {
-  color: #D6D6D6;
-  font-size: 1rem; }
-
-form .input-item,
-form .text-item {
-  position: relative;
-  padding-bottom: 1rem; }
-  form .input-item.optional label.form-label::after,
-  form .text-item.optional label.form-label::after {
-    content: '- optional';
-    font-weight: 300;
-    font-style: italic;
-    padding-left: .5rem; }
-  form .input-item .icon-question,
-  form .text-item .icon-question {
-    padding-left: 0.35rem;
-    cursor: pointer;
-    vertical-align: middle; }
-  form .input-item .form-text.to-right,
-  form .text-item .form-text.to-right {
-    position: absolute;
-    right: 0; }
-  form .input-item textarea,
-  form .text-item textarea {
-    max-height: 10rem; }
-  form .input-item .input-group-text,
-  form .text-item .input-group-text {
-    background-color: #E3EAEE;
-    color: #343434;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none; }
-
-form .btn {
-  margin-top: 1rem; }
+    padding-bottom: 1rem; }
+    form .input-item.optional label.form-label::after,
+    form .text-item.optional label.form-label::after {
+      content: '- optional';
+      font-weight: 300;
+      font-style: italic;
+      padding-left: .5rem; }
+    form .input-item .icon-question,
+    form .text-item .icon-question {
+      padding-left: 0.35rem;
+      cursor: pointer;
+      vertical-align: middle; }
+    form .input-item .form-text.to-right,
+    form .text-item .form-text.to-right {
+      position: absolute;
+      right: 0; }
+    form .input-item textarea,
+    form .text-item textarea {
+      max-height: 10rem; }
+    form .input-item .input-group-text,
+    form .text-item .input-group-text {
+      background-color: #E3EAEE;
+      color: #343434;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none; }
+  form .btn {
+    margin-top: 1rem; }
 
 .choices {
   width: 100%; }

--- a/app/static/js/grid_model_topology.js
+++ b/app/static/js/grid_model_topology.js
@@ -288,6 +288,8 @@ function populateForm(nodeDOM, submit=false, show=true) {
 
             updateInputTimeseries();
 
+            updateCapacityFieldsVisibility();
+
             if (submit)
                 submitForm();
             if (show)
@@ -663,6 +665,25 @@ editor.on('connectionUnselected', _ => {
     selectedElement = null;
 });
 
+function updateCapacityFieldsVisibility() {
+    const optimizeCapInput = guiModalDOM.querySelector('input[name="optimize_cap"]');
+    console.log("optimize_cap element:", optimizeCapInput);
+    if (!optimizeCapInput) return;
+
+    const maxCapacityGroup = guiModalDOM.querySelector('input[name="maximum_capacity"]')?.closest('.form-group');
+    const installedCapacityGroup = guiModalDOM.querySelector('input[name="installed_capacity"]')?.closest('.form-group');
+    const ageInstalledGroup = guiModalDOM.querySelector('input[name="age_installed"]')?.closest('.form-group');
+
+    function toggleFields() {
+        const isOptimized = optimizeCapInput.checked;
+        if (maxCapacityGroup) maxCapacityGroup.style.display = isOptimized ? '' : 'none';
+        if (installedCapacityGroup) installedCapacityGroup.style.display = isOptimized ? 'none' : '';
+        if (ageInstalledGroup) ageInstalledGroup.style.display = isOptimized ? 'none' : '';
+    }
+
+    toggleFields();
+    optimizeCapInput.addEventListener('change', toggleFields);
+}
 
 // TODO potentially remove this function
 function updateInputTimeseries(){

--- a/app/static/js/grid_model_topology.js
+++ b/app/static/js/grid_model_topology.js
@@ -288,6 +288,8 @@ function populateForm(nodeDOM, submit=false, show=true) {
 
             updateInputTimeseries();
 
+            updateCapacityFieldsVisibility();
+
             if (submit)
                 submitForm();
             if (show)
@@ -393,6 +395,7 @@ function submitForm() {
         } else {
             // assign the content of the form to the form tag of the modal
             guiModalDOM.querySelector('form .modal-body').innerHTML = jsonRes.form_html;
+            updateCapacityFieldsVisibility();
             // make certain to show form
             guiModal.show();
         }
@@ -663,6 +666,25 @@ editor.on('connectionUnselected', _ => {
     selectedElement = null;
 });
 
+function updateCapacityFieldsVisibility() {
+    const optimizeCapInput = guiModalDOM.querySelector('input[name="optimize_cap"]');
+    console.log("optimize_cap element:", optimizeCapInput);
+    if (!optimizeCapInput) return;
+
+    const maxCapacityGroup = guiModalDOM.querySelector('input[name="maximum_capacity"]')?.closest('.form-group');
+    const installedCapacityGroup = guiModalDOM.querySelector('input[name="installed_capacity"]')?.closest('.form-group');
+    const ageInstalledGroup = guiModalDOM.querySelector('input[name="age_installed"]')?.closest('.form-group');
+
+    function toggleFields() {
+        const isOptimized = optimizeCapInput.checked;
+        if (maxCapacityGroup) maxCapacityGroup.style.display = isOptimized ? '' : 'none';
+        if (installedCapacityGroup) installedCapacityGroup.style.display = isOptimized ? 'none' : '';
+        if (ageInstalledGroup) ageInstalledGroup.style.display = isOptimized ? 'none' : '';
+    }
+
+    toggleFields();
+    optimizeCapInput.addEventListener('change', toggleFields);
+}
 
 // TODO potentially remove this function
 function updateInputTimeseries(){

--- a/app/static/scss/components/_forms.scss
+++ b/app/static/scss/components/_forms.scss
@@ -21,7 +21,7 @@ form {
     background-color: $primary-color-1;
   }
 
-/*  .toggle-switch {
+  .toggle-switch {
     position: relative;
     display: inline-block;
     width: 48px;
@@ -62,7 +62,6 @@ form {
       }
     }
   }
-*/
   .form-group {
     margin-bottom: 1rem;
     color: $primary-color-2;

--- a/app/static/scss/components/_forms.scss
+++ b/app/static/scss/components/_forms.scss
@@ -21,6 +21,48 @@ form {
     background-color: $primary-color-1;
   }
 
+/*  .toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 48px;
+    height: 24px;
+
+    input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      inset: 0;
+      background-color: $primary-gray-color-2;
+      border-radius: 24px;
+      transition: 0.3s;
+
+      &::before {
+        content: "";
+        position: absolute;
+        height: 18px;
+        width: 18px;
+        left: 3px;
+        bottom: 3px;
+        background-color: $white;
+        border-radius: 50%;
+        transition: 0.3s;
+      }
+    }
+
+    input:checked + .toggle-slider {
+      background-color: $primary-color-1;
+
+      &::before {
+        transform: translateX(24px);
+      }
+    }
+  }
+*/
   .form-group {
     margin-bottom: 1rem;
     color: $primary-color-2;

--- a/app/templates/asset/asset_create_form.html
+++ b/app/templates/asset/asset_create_form.html
@@ -42,6 +42,23 @@
               {% endif %}
       </div>
     {% endif %}
+    {% if form|has_toggle_parameters %}
+      <div class="row">
+        <div class="col">
+          <h3>{% translate "Settings" %}</h3>
+          <div class="d-flex gap-5">
+            {% for field in form %}
+              {% if field.name|is_toggle_parameter %}
+                <div class="form-group{% if field.errors %} invalid{% endif %}">
+                  {{ field }}
+                  <label>{{ field.label }}</label>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
     <div class="row align-items-start">
       {% if form|has_economical_parameters %}
         <div class="col">


### PR DESCRIPTION
Boolean form fields _(optimize_cap, dispatchable, renewable_asset)_ are now displayed as toggle switches instead of yes/no dropdowns. 
A new "Settings" section was added above the economical parameters to group these fields together.

**Note:** 
Toggle styles in _forms.scss are commented out and not functional yet.
Styles are currently applied inline in the widget.

Fixes #483.