### PR TITLE
Fix tkinter dependency problem

### DIFF
--- a/app/compose/production/app_postgres/Dockerfile
+++ b/app/compose/production/app_postgres/Dockerfile
@@ -13,7 +13,7 @@ COPY app/requirements/${BUILD_ENVIRONMENT}.txt ${CONFIG_ROOT}/${BUILD_ENVIRONMEN
 
 # Install gettext utilities for translations
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gettext-base gettext git tk && \
+    apt-get install -y --no-install-recommends gettext-base gettext git && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip \

--- a/app/requirements/base.txt
+++ b/app/requirements/base.txt
@@ -12,7 +12,6 @@ flower==2.0.1
 redis==7.4.0
 oemof-eesyplan[importer] @ git+https://github.com/oemof/oemof-eesyplan.git@main
 oemof-datapackage @ git+https://github.com/oemof/oemof-datapackage.git@dev
-oemof-visio
 httpx<0.28
 jsonschema==4.26.0
 libsass==0.23.0


### PR DESCRIPTION
The error 
```
~   File "/usr/local/lib/python3.12/site-packages/oemof/eesyplan/io.py", line 3, in <module>
~     from tkinter import Tk
~   File "/usr/local/lib/python3.12/tkinter/__init__.py", line 38, in <module>
~     import _tkinter # If this fails your Python may not be configured for Tk
``` 

Doesn't appear with the newest version of eesyplan, therefore one can remove the tk install step from the Dockerfile

Tested on sandbox