### PR TITLE
Update outdated debian version

### DIFF
--- a/app/compose/production/app_postgres/Dockerfile
+++ b/app/compose/production/app_postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-trixie
 
 RUN echo POSTGRES
 ENV APP_ROOT /src


### PR DESCRIPTION
Bullseye debian (11) reached its end of long term support, causing the CI to fail since the Dockerfile is using this image. Updated to current stable release trixie (13). See https://www.debian.org/releases/